### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./benchmark.sh
 
       - name: Upload JMH Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jmh-results
           path: reports/*.json


### PR DESCRIPTION
v2 is deprecated and no longer runs as of 2024-06-30. This project is not using any of the action's features that had breaking changes, so just updating the version number should work.

I was curious to see the logs from the most recent run because running the benchmarks locally for me showed some exceptions being thrown during the tests, but when I opened it up Github told me the logs had expired. It also showed a warning that this `build.yml` includes a deprecated action, so I figured we can fix it and get a fresh run with log output while we're at it. :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the automated artifact upload step to a newer version, enhancing the build process's reliability and performance while keeping the artifact configuration unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->